### PR TITLE
Include 'master' branch as an option for version tagging

### DIFF
--- a/.github/workflows/tag_version_and_release.yaml
+++ b/.github/workflows/tag_version_and_release.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - master
   pull_request:
     types:
       - labeled


### PR DESCRIPTION
## Description

Automated version tagging on PR merging is not working right now because the default branch of this repository uses the legacy default name, `master`, instead of `main`. This updates the workflow to trigger on both branch names.
